### PR TITLE
propagation: fix regression in angular spectrum transfer function impl

### DIFF
--- a/prysm/propagation.py
+++ b/prysm/propagation.py
@@ -405,8 +405,8 @@ def angular_spectrum_transfer_function(samples, wvl, dx, z):
     ky, kx = (fft.fftfreq(s, dx).astype(config.precision) for s in samples)
     kxx = kx * kx
     kyy = ky * ky
-    kyy = np.broadcast_to(ky, samples).swapaxes(0, 1)
-    kxx = np.broadcast_to(kx, samples)
+    kyy = np.broadcast_to(kyy, samples).swapaxes(0, 1)
+    kxx = np.broadcast_to(kxx, samples)
 
     return np.exp(-1j * np.pi * wvl * z * (kxx + kyy))
 


### PR DESCRIPTION
I came across a data centering regression in the current `master` branch with regard to `Wavefront.free_space`. The following code results in decentered output in af89c94d500a274eda664188ddb97fcae30c6ac5 but appears fine in v0.21:
```python
import prysm.coordinates
import prysm.geometry
import prysm.propagation

diameter = 550 # mm
xi, eta = prysm.coordinates.make_xy_grid(256, diameter=diameter)
r, t = prysm.coordinates.cart_to_polar(xi, eta)
A = prysm.geometry.truecircle(diameter / 2, r)
dx = xi[0, 1] - xi[0, 0]
wf = prysm.propagation.Wavefront.from_amp_and_phase(A, None, 2e3, dx)
wf.free_space(dz=1000).intensity.plot2d()
```

Further investigation isolated this issue to typos in the optimization introduced in 61f7ee4f10754d1cb8eae90a019c55256c19ffa9. This PR fixes the regression.