### PR TITLE
fttools: fix complex output of iczt2

### DIFF
--- a/prysm/fttools.py
+++ b/prysm/fttools.py
@@ -542,7 +542,7 @@ class ChirpZTransformExecutor:
         # but np.conj copies real inputs, so we optimize for that.
         if np.iscomplexobj(ary):
             ary = np.conj(ary)
-        xformed = self.czt2(ary, Q, samples, shift)
+        xformed = np.conj(self.czt2(ary, Q, samples, shift))
         return xformed
 
     def _setup_bases(self, key):

--- a/tests/test_fttools.py
+++ b/tests/test_fttools.py
@@ -55,3 +55,10 @@ def test_czt_reverses_self_(samples):
     fwd = fttools.czt.czt2(inp, 1, samples)
     back = fttools.czt.iczt2(fwd, 1, samples)
     assert np.allclose(inp, back)
+
+@pytest.mark.parametrize('samples', ARRAY_SIZES)
+def test_czt_reverses_self_complex(samples):
+    inp = np.random.rand(samples, samples) + 1.0j * np.random.rand(samples, samples)
+    fwd = fttools.czt.czt2(inp, 1, samples)
+    back = fttools.czt.iczt2(fwd, 1, samples)
+    assert np.allclose(inp, back)


### PR DESCRIPTION
correct the inversion of the imaginary part's sign of the output (#104).