### PR TITLE
fttools: fix NameError

### DIFF
--- a/prysm/fttools.py
+++ b/prysm/fttools.py
@@ -542,7 +542,7 @@ class ChirpZTransformExecutor:
         # but np.conj copies real inputs, so we optimize for that.
         if np.iscomplexobj(ary):
             ary = np.conj(ary)
-        xformed = np.conj(self.czt2(ary, Q, samples, shift))
+        xformed = np.conj(self.czt2(ary, Q, samples_out, shift))
         return xformed
 
     def _setup_bases(self, key):


### PR DESCRIPTION
I fixed a NameError caused by commit 388d43005dacd5e663036061abf40998bc51dfa3.