### PR TITLE
Updated pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ version = "0.22"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-numpy = "^1.26.4"
+numpy = ">=1,<3"
+h5py = '*'
+scipy = '*'
 
 [tool.coverage.run]
 include = ["prysm/*",]


### PR DESCRIPTION
Updated pyproject.toml to accept any NumPy 1.x or 2.x, and explicitly lists the dependencies on h5py and scipy.