### PR TITLE
Handle cupy-typed f and g in optimizers

### DIFF
--- a/prysm/x/optym/optimizers.py
+++ b/prysm/x/optym/optimizers.py
@@ -711,6 +711,11 @@ class F77LBFGSB:
                 if g.ndim != 1:
                     g = g.ravel()
 
+                # Handle cupy-typed f and g
+                if hasattr(f, "get"):
+                    f = f.get()
+                    g = g.get()
+
                 self.f[:] = f
                 self.g[:] = g
                 self._call_fortran()
@@ -864,6 +869,11 @@ class CLBFGSB:
                 f, g = self.fg(self.x)
                 if g.ndim != 1:
                     g = g.ravel()
+
+                # Handle cupy-typed f and g
+                if hasattr(f, "get"):
+                    f = f.get()
+                    g = g.get()
 
                 self.f[...] = f
                 self.g[:] = g


### PR DESCRIPTION
Something I've been meaning to commit since the 2025 JATIS paper, this converts the function and gradient evals to numpy arrays if the cupy backend is being used

I added to the C-backend one too, but wasn't sure if it needed it