### PR TITLE
Fix polychromatic defocus comment

### DIFF
--- a/docs/source/how-tos/Polychromatic Propagation.ipynb
+++ b/docs/source/how-tos/Polychromatic Propagation.ipynb
@@ -60,7 +60,7 @@
     "\n",
     "r_aber = r / r_aper\n",
     "\n",
-    "coef = wvl0 * 1e3 * 15 # 10 waves of defocus\n",
+    "coef = wvl0 * 1e3 * 15 # 15 waves of defocus\n",
     "phs = polynomials.hopkins(0,2,0,r_aber,t,1) * coef\n",
     "\n",
     "amp = geometry.circle(r_aper, r)\n",


### PR DESCRIPTION
Summary:
- Align the Polychromatic Propagation notebook comment with the `15` wave defocus coefficient.

Addresses item 4 in #117.

Validation:
- Not run locally.