### PR TITLE
Handle sparse Q2D sine and cosine terms

### DIFF
--- a/prysm/polynomials/qpoly.py
+++ b/prysm/polynomials/qpoly.py
@@ -1265,8 +1265,8 @@ def Q2d_nm_c_to_a_b(nms, coefs):
             if bc[k][i] is None:
                 bc[k][i] = 0
 
-    max_m_a = max(list(ac.keys()))
-    max_m_b = max(list(bc.keys()))
+    max_m_a = max(ac.keys()) if ac else 0
+    max_m_b = max(bc.keys()) if bc else 0
     max_m = max(max_m_a, max_m_b)
     ac_ret = []
     bc_ret = []

--- a/tests/test_polynomials.py
+++ b/tests/test_polynomials.py
@@ -685,3 +685,23 @@ def test_qcon_zzprime_q2d():
     ddy *= mask
     assert np.allclose(dx, ddx, atol=1)
     assert np.allclose(dy, ddy, atol=1)
+
+
+def test_q2d_nm_c_to_a_b_allows_only_cosine_terms():
+    cms, ams, bms = polynomials.qpoly.Q2d_nm_c_to_a_b(
+        [(0, 0), (1, 1)],
+        [1, 2],
+    )
+    assert cms == [1]
+    assert ams == [[0, 2]]
+    assert bms == [[]]
+
+
+def test_q2d_nm_c_to_a_b_allows_only_sine_terms():
+    cms, ams, bms = polynomials.qpoly.Q2d_nm_c_to_a_b(
+        [(0, 0), (1, -1)],
+        [1, 2],
+    )
+    assert cms == [1]
+    assert ams == [[]]
+    assert bms == [[0, 2]]


### PR DESCRIPTION
Summary:
- Avoid calling `max()` on an empty sine or cosine coefficient mapping in `Q2d_nm_c_to_a_b`.
- Return empty coefficient rows for the missing sign so one-sided Q2D coefficient inputs can still be passed to `compute_z_zprime_Q2d`.
- Add regression coverage for cosine-only and sine-only inputs.

Fixes #87.

Validation:
- Not run locally.