### PR TITLE
DOC: Use named optical parameters in diffraction tutorial

### DIFF
--- a/docs/source/tutorials/First Diffraction Model.ipynb
+++ b/docs/source/tutorials/First Diffraction Model.ipynb
@@ -37,7 +37,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xi, eta = make_xy_grid(256, diameter=10)\n",
+    "diameter = 10\n",
+    "radius = diameter / 2\n",
+    "fno = 10\n",
+    "efl = fno * diameter\n",
+    "\n",
+    "xi, eta = make_xy_grid(256, diameter=diameter)\n",
     "r, t = cart_to_polar(xi, eta)"
    ]
   },
@@ -57,7 +62,7 @@
     "from prysm.geometry import circle\n",
     "from matplotlib import pyplot as plt\n",
     "\n",
-    "A = circle(5, r)\n",
+    "A = circle(radius, r)\n",
     "plt.imshow(A)"
    ]
   },
@@ -70,7 +75,7 @@
     "$$\n",
     "\\phi(\\rho,\\theta) = W_{040} \\rho^4 $$\n",
     "\n",
-    "using $\\rho = r / 5$, the radius of the pupil."
+    "using $\\rho = r / \\mathrm{radius}$ to normalize the pupil coordinates."
    ]
   },
   {
@@ -81,7 +86,7 @@
    "source": [
     "from prysm.polynomials import hopkins\n",
     "\n",
-    "rho = r / 5\n",
+    "rho = r / radius\n",
     "phi = hopkins(0, 4, 0, rho, t, 1) # 1 = H, field height\n",
     "plt.imshow(phi)"
    ]
@@ -147,9 +152,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "E = wf.focus(100)\n",
+    "E = wf.focus(efl)\n",
     "psf = E.intensity\n",
-    "fno = 10\n",
     "psf_radius = 1.22*HeNe*fno\n",
     "psf.plot2d(xlim=psf_radius*10, power=1/3, cmap='gray', interpolation='bicubic')"
    ]
@@ -170,7 +174,7 @@
    "outputs": [],
    "source": [
     "wf = Wavefront.from_amp_and_phase(A, phi500, HeNe, dx) # wf == P\n",
-    "E = wf.focus(100)\n",
+    "E = wf.focus(efl)\n",
     "psf = E.intensity\n",
     "psf.plot2d(xlim=psf_radius*10, power=1/3, cmap='gray', interpolation='bicubic')"
    ]
@@ -191,7 +195,7 @@
    "outputs": [],
    "source": [
     "wf = Wavefront.from_amp_and_phase(A, None, HeNe, dx)\n",
-    "E = wf.focus(100, Q=8)\n",
+    "E = wf.focus(efl, Q=8)\n",
     "psf = E.intensity\n",
     "psf.plot2d(xlim=psf_radius*10, power=1/3, cmap='gray', interpolation='bicubic')"
    ]


### PR DESCRIPTION
## Summary

- define the pupil diameter, radius, f-number, and effective focal length as named variables
- reuse those variables throughout the first diffraction model tutorial
- clarify that the pupil radius is used to normalize the radial coordinate

This addresses item 3 in #117 and keeps the tutorial's numerical behavior unchanged.

## Validation

- `ruff check "docs/source/tutorials/First Diffraction Model.ipynb"`
- executed all 9 code cells sequentially against the local Prysm source with a non-interactive Matplotlib backend
- `git diff --check`

## Tool disclosure

Codex assisted with the implementation and validation. I reviewed the complete diff and the resulting notebook code.
