### PR TITLE
DOC: Remove unsupported FFTDFT example

### DIFF
--- a/docs/source/03 - diffraction and physical optics college/103 - fixed-sampling dft propagation.ipynb
+++ b/docs/source/03 - diffraction and physical optics college/103 - fixed-sampling dft propagation.ipynb
@@ -46,11 +46,9 @@
     "The user need not have a deep understanding of the mathematics of these\n",
     "methods; the DFT propagation API allows any of them to be selected with a\n",
     "simple keyword.  As a user, you can benchmark any of them and select the most\n",
-    "optimal for your given propagation and hardware.  There is a third option,\n",
-    "`FFTDFT`, which is somewhere in between the two in how it works and is the\n",
-    "fastest in most cases.\n",
+    "optimal for your given propagation and hardware.\n",
     "\n",
-    "We'll demonstrate DFT (MDFT, CZT, FFTDFT) based propagations in this notebook,\n",
+    "We'll demonstrate MDFT- and CZT-based propagations in this notebook,\n",
     "using the same system as was used in the 101 notebook.  We begin with the usual\n",
     "imports and set up our simple reference F/10, 100mm focal length system at HeNe:"
    ]
@@ -118,7 +116,7 @@
    "id": "6bed497e",
    "metadata": {},
    "source": [
-    "## MDFT, CZT, FFTDFT\n",
+    "## MDFT and CZT\n",
     "\n",
     "When setting up a DFT propagation, your code is broken into two steps:\n",
     "\n",
@@ -143,11 +141,9 @@
     "\n",
     "ex_dft = wf.prepare_executor(EFL, dxfine, Nfine, kind='mdft')\n",
     "ex_czt = wf.prepare_executor(EFL, dxfine, Nfine, kind='czt')\n",
-    "ex_fftdft = wf.prepare_executor(EFL, dxfine, Nfine, kind='fftdft')\n",
     "\n",
     "psf_dft = wf.focus_dft(ex_dft).intensity\n",
     "psf_czt = wf.focus_dft(ex_czt).intensity\n",
-    "psf_fftdft = wf.focus_dft(ex_fftdft).intensity\n",
     "\n",
     "print(f'DFT focal dx = {psf_dft.dx:.3f} um   ({psf_dft.data.shape[0]} samples)')\n",
     "psf_dft.plot2d(xlim=12*airy_radius, power=1/4);"
@@ -159,8 +155,8 @@
    "metadata": {},
    "source": [
     "The grid is smaller than the region that was plotted, but the data within it is\n",
-    "the same.  MDFT and CZT allow arbitrary grids to be computed, while FFTDFT\n",
-    "requires integer sampling ratios.  We can show in 1D that the data is the same:"
+    "the same.  Both MDFT and CZT allow arbitrary grids to be computed.  We can\n",
+    "show in 1D that the data is the same:"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- remove references to the unavailable `FFTDFT` executor from the new fixed-sampling propagation notebook
- keep the example focused on the supported MDFT and CZT executors
- update the surrounding explanation to match the current `prepare_executor` API

## Problem

The notebook passed `kind='fftdft'` to `Wavefront.prepare_executor`, but the current implementation supports only `kind='mdft'` and `kind='czt'`. As a result, executing the notebook stopped with:

```text
ValueError: kind must be 'mdft' or 'czt', got 'fftdft'
```

This change removes the unsupported path so the new diffraction college notebook runs from start to finish.

## Validation

- `ruff check "docs/source/03 - diffraction and physical optics college/103 - fixed-sampling dft propagation.ipynb"`
- parsed the notebook as JSON
- executed all 5 code cells sequentially against the local Prysm source with a non-interactive Matplotlib backend
- `git diff --check`

## Tool disclosure

Codex assisted with identifying the failing notebook cell, implementing the documentation update, and running the checks above. I reviewed the complete diff and the resulting notebook code.
